### PR TITLE
Extract bitrate from streams if present

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -38,6 +38,7 @@ type Streams struct {
 	DurationTs 		 	  	int				`json:"duration_ts"`
 	Duration 			  	string			`json:"duration"`
 	Disposition           	Disposition		`json:"disposition"`
+	BitRate					string			`json:"bit_rate"`
 }
 
 type Disposition struct {


### PR DESCRIPTION
Audio streams throw out a bitrate, whenever video bitrate is required, you could easily subtract overall bitrate and audio bitrate.