### PR TITLE
Add filter string to ffmpeg args

### DIFF
--- a/models/media.go
+++ b/models/media.go
@@ -45,9 +45,13 @@ type Mediafile struct {
     hlsPlaylistType       string
     hlsSegmentDuration    int
     metadata              Metadata
+    filter                string
 }
 
 /*** SETTERS ***/
+func (m *Mediafile) SetFilter(v string){
+  m.filter = v
+}
 
 func (m *Mediafile) SetAspect(v string) {
   m.aspect = v
@@ -194,6 +198,10 @@ func (m *Mediafile) SetMetadata(v Metadata) {
 }
 
 /*** GETTERS ***/
+
+func (m *Mediafile) Filter() string {
+  return m.filter
+}
 
 func (m *Mediafile) Aspect() string {
   return m.aspect
@@ -382,6 +390,7 @@ func (m *Mediafile) ToStrCommand() string {
     "OutputFormat",
     "HlsSegmentDuration",
     "HlsPlaylistType",
+    "Filter",
     "OutputPath",
   }
   for _, name := range opts {
@@ -400,6 +409,12 @@ func (m *Mediafile) ToStrCommand() string {
 
 }
 
+func (m *Mediafile) ObtainFilter() string{
+  if m.filter != "" {
+    return fmt.Sprintf("-vf \"%s\"", m.filter)
+  }
+  return ""
+}
 
 func (m *Mediafile) ObtainAspect() string {
   // Set aspect


### PR DESCRIPTION
Useful option to make scale and other things
Scale :
https://superuser.com/questions/547296/resizing-videos-with-ffmpeg-avconv-to-fit-into-static-sized-player

Save first frame in jpg:
ffmpeg -i inputfile.mkv -vf "select=eq(n\,0)" -q:v 3 output_image.jpg