### PR TITLE
Method SetAudioBitrate must receive a string value

### DIFF
--- a/models/media.go
+++ b/models/media.go
@@ -22,7 +22,7 @@ type Mediafile struct {
 	minKeyframe           int
 	keyframeInterval      int
 	audioCodec            string
-	audioBitrate          int
+	audioBitrate          string
 	audioChannels         int
 	bufferSize            int
 	threads               int
@@ -130,7 +130,7 @@ func (m *Mediafile) SetAudioCodec(v string) {
 	m.audioCodec = v
 }
 
-func (m *Mediafile) SetAudioBitRate(v int) {
+func (m *Mediafile) SetAudioBitRate(v string) {
 	m.audioBitrate = v
 }
 
@@ -333,7 +333,7 @@ func (m *Mediafile) AudioCodec() string {
 	return m.audioCodec
 }
 
-func (m *Mediafile) AudioBitrate() int {
+func (m *Mediafile) AudioBitrate() string {
 	return m.audioBitrate
 }
 
@@ -640,8 +640,8 @@ func (m *Mediafile) ObtainAudioCodec() []string {
 }
 
 func (m *Mediafile) ObtainAudioBitRate() []string {
-	if m.audioBitrate != 0 {
-		return []string{"-b:a", fmt.Sprintf("%d", m.audioBitrate)}
+	if m.audioBitrate != "" {
+		return []string{"-b:a", m.audioBitrate}
 	}
 	return nil
 }


### PR DESCRIPTION
e.g.

ffmpeg -y -i ~/el_club/el_club.avi -r 30 -c:v libx264 -profile:v baseline -c:a aac **-b:a 192k** -strict -2 -f hls -hls_list_size 0 -hls_time 10 /tmp/axe/processed/el_club/media.m3u8

ffmpeg tests:
https://github.com/FFmpeg/FFmpeg/blob/a0ac49e38ee1d1011c394d7be67d0f08b2281526/tests/fate/aac.mak