### PR TITLE
Implement Pipe Protocol: Pipe-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ FFMPEG wrapper written in GO which allows to obtain the progress.
  - Windows
 
 # Getting started
-How to transcode a media file
+## How to transcode a media file
 ```shell
 go get github.com/xfrr/goffmpeg
 ```
@@ -47,7 +47,7 @@ func main() {
 
 }
 ```
-How to get the transcoding progress
+## How to get the transcoding progress
 ```go
 ...
 func main() {
@@ -75,8 +75,36 @@ func main() {
 
 }
 ```
+
+## How to pipe in data using the (pipe protocol)[https://ffmpeg.org/ffmpeg-protocols.html#pipe]
+```go
+func main() {
+
+	// Create new instance of transcoder
+    trans := new(transcoder.Transcoder)
+
+	// Initialize an empty transcoder
+    err := trans.InitializeEmptyTranscoder()
+    // Handle error...
+
+	// Set the output path on the transcoder
+	trans.SetOutputPath("/tmp/data/out/output.mp4")
+
+	// Set a command such that its output should be passed as stdin to ffmpeg
+	err = trans.CreateInputPipe(exec.Command("cat", "/tmp/data/testmpeg"))
+	// Handle error...
+
+	// Start transcoder process without checking progress
+	done := trans.Run(true)
+
+	// This channel is used to wait for the transcoding process to end
+	err = <-done
+
+}
+```
+
 # Progress properties
-```golang
+```go
 type Progress struct {
 	FramesProcessed string
 	CurrentTime     string

--- a/models/media.go
+++ b/models/media.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"fmt"
+	"os/exec"
 	"reflect"
 	"strconv"
 	"strings"
@@ -40,6 +41,7 @@ type Mediafile struct {
 	seekUsingTsInput      bool
 	seekTimeInput         string
 	inputPath             string
+	inputPipeCommand      *exec.Cmd
 	hideBanner            bool
 	outputPath            string
 	outputFormat          string
@@ -196,6 +198,10 @@ func (m *Mediafile) SetCopyTs(val bool) {
 
 func (m *Mediafile) SetInputPath(val string) {
 	m.inputPath = val
+}
+
+func (m *Mediafile) SetInputPipeCommand(command *exec.Cmd) {
+	m.inputPipeCommand = command
 }
 
 func (m *Mediafile) SetHideBanner(val bool) {
@@ -409,6 +415,10 @@ func (m *Mediafile) InputPath() string {
 	return m.inputPath
 }
 
+func (m *Mediafile) InputPipeCommand() *exec.Cmd {
+	return m.inputPipeCommand
+}
+
 func (m *Mediafile) HideBanner() bool {
 	return m.hideBanner
 }
@@ -481,6 +491,7 @@ func (m *Mediafile) ToStrCommand() []string {
 		"RtmpLive",
 		"InputInitialOffset",
 		"InputPath",
+		"InputPipeCommand",
 		"HideBanner",
 
 		"Aspect",
@@ -569,7 +580,17 @@ func (m *Mediafile) ObtainAspect() []string {
 }
 
 func (m *Mediafile) ObtainInputPath() []string {
-	return []string{"-i", m.inputPath}
+	if m.inputPath != "" {
+		return []string{"-i", m.inputPath}
+	}
+	return nil
+}
+
+func (m *Mediafile) ObtainInputPipeCommand() []string {
+	if m.inputPipeCommand != nil {
+		return []string{"-i", "pipe:0"}
+	}
+	return nil
 }
 
 func (m *Mediafile) ObtainHideBanner() []string {

--- a/tests/transcoding_test.go
+++ b/tests/transcoding_test.go
@@ -1,15 +1,16 @@
 package test
 
 import (
+	"os/exec"
 	"testing"
 
-	"github.com/xfrr/goffmpeg/transcoder"
+	"github.com/muhammadharis/goffmpeg/transcoder"
 )
 
 func TestInputNotFound(t *testing.T) {
 
 	var inputPath = "/data/testmkv"
-	var outputPath = "/data/testmp4.mp4"
+	var outputPath = "/data/out/testmp4.mp4"
 
 	trans := new(transcoder.Transcoder)
 
@@ -43,7 +44,7 @@ func TestTranscoding3GP(t *testing.T) {
 func TestTranscodingAVI(t *testing.T) {
 
 	var inputPath = "/data/testavi"
-	var outputPath = "/data/testmp4.mp4"
+	var outputPath = "/data/out/testmp4.mp4"
 
 	trans := new(transcoder.Transcoder)
 
@@ -64,7 +65,7 @@ func TestTranscodingAVI(t *testing.T) {
 func TestTranscodingFLV(t *testing.T) {
 
 	var inputPath = "/data/testflv"
-	var outputPath = "/data/testmp4.mp4"
+	var outputPath = "/data/out/testmp4.mp4"
 
 	trans := new(transcoder.Transcoder)
 
@@ -85,7 +86,7 @@ func TestTranscodingFLV(t *testing.T) {
 func TestTranscodingMKV(t *testing.T) {
 
 	var inputPath = "/data/testmkv"
-	var outputPath = "/data/testmp4.mp4"
+	var outputPath = "/data/out/testmp4.mp4"
 
 	trans := new(transcoder.Transcoder)
 
@@ -106,7 +107,7 @@ func TestTranscodingMKV(t *testing.T) {
 func TestTranscodingMOV(t *testing.T) {
 
 	var inputPath = "/data/testmov"
-	var outputPath = "/data/testmp4.mp4"
+	var outputPath = "/data/out/testmp4.mp4"
 
 	trans := new(transcoder.Transcoder)
 
@@ -127,7 +128,7 @@ func TestTranscodingMOV(t *testing.T) {
 func TestTranscodingMPEG(t *testing.T) {
 
 	var inputPath = "/data/testmpeg"
-	var outputPath = "/data/testmp4.mp4"
+	var outputPath = "/data/out/testmp4.mp4"
 
 	trans := new(transcoder.Transcoder)
 
@@ -148,7 +149,7 @@ func TestTranscodingMPEG(t *testing.T) {
 func TestTranscodingOGG(t *testing.T) {
 
 	var inputPath = "/data/testogg"
-	var outputPath = "/data/testmp4.mp4"
+	var outputPath = "/data/out/testmp4.mp4"
 
 	trans := new(transcoder.Transcoder)
 
@@ -169,7 +170,7 @@ func TestTranscodingOGG(t *testing.T) {
 func TestTranscodingWAV(t *testing.T) {
 
 	var inputPath = "/data/testwav"
-	var outputPath = "/data/testmp4.mp4"
+	var outputPath = "/data/out/testmp4.mp4"
 
 	trans := new(transcoder.Transcoder)
 
@@ -190,7 +191,7 @@ func TestTranscodingWAV(t *testing.T) {
 func TestTranscodingWEBM(t *testing.T) {
 
 	var inputPath = "/data/testwebm"
-	var outputPath = "/data/testmp4.mp4"
+	var outputPath = "/data/out/testmp4.mp4"
 
 	trans := new(transcoder.Transcoder)
 
@@ -211,7 +212,7 @@ func TestTranscodingWEBM(t *testing.T) {
 func TestTranscodingWMV(t *testing.T) {
 
 	var inputPath = "/data/testwmv"
-	var outputPath = "/data/testmp4.mp4"
+	var outputPath = "/data/out/testmp4.mp4"
 
 	trans := new(transcoder.Transcoder)
 
@@ -229,10 +230,33 @@ func TestTranscodingWMV(t *testing.T) {
 	}
 }
 
+func TestTranscodingInputPipe(t *testing.T) {
+
+	// Tests pipe with input mpeg, output mp4 using cat command for pipe-in
+	var outputPath = "/data/out/testmp4.mp4"
+
+	trans := new(transcoder.Transcoder)
+	err := trans.InitializeEmptyTranscoder()
+	trans.SetOutputPath(outputPath)
+	trans.CreateInputPipe(exec.Command("cat", "/data/testmpeg"))
+
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	done := trans.Run(false)
+	err = <-done
+	if err != nil {
+		t.Error(err)
+		return
+	}
+}
+
 func TestTranscodingProgress(t *testing.T) {
 
 	var inputPath = "/data/testavi"
-	var outputPath = "/data/testmp4.mp4"
+	var outputPath = "/data/out/testmp4.mp4"
 
 	trans := new(transcoder.Transcoder)
 

--- a/tests/transcoding_test.go
+++ b/tests/transcoding_test.go
@@ -4,7 +4,7 @@ import (
 	"os/exec"
 	"testing"
 
-	"github.com/muhammadharis/goffmpeg/transcoder"
+	"github.com/xfrr/goffmpeg/transcoder"
 )
 
 func TestInputNotFound(t *testing.T) {

--- a/transcoder/transcoder.go
+++ b/transcoder/transcoder.go
@@ -13,8 +13,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/muhammadharis/goffmpeg/models"
 	"github.com/xfrr/goffmpeg/ffmpeg"
+	"github.com/xfrr/goffmpeg/models"
 	"github.com/xfrr/goffmpeg/utils"
 )
 

--- a/transcoder/transcoder.go
+++ b/transcoder/transcoder.go
@@ -79,8 +79,8 @@ func (t Transcoder) GetCommand() []string {
 	return rcommand
 }
 
-// InitializeTranscoder initializes the fields necessary for a blank transcoder
-func (t *Transcoder) InitializeTranscoder() error {
+// InitializeEmptyTranscoder initializes the fields necessary for a blank transcoder
+func (t *Transcoder) InitializeEmptyTranscoder() error {
 	var Metadata models.Metadata
 
 	var err error
@@ -218,7 +218,7 @@ func (t *Transcoder) Run(progress bool) <-chan error {
 			return
 		}
 
-		// Run the pipe-in command if it's been set
+		// Run the pipe-in command if it has been set
 		if t.mediafile.InputPipeCommand() != nil {
 			err = t.mediafile.InputPipeCommand().Run()
 			if err != nil {

--- a/transcoder/transcoder.go
+++ b/transcoder/transcoder.go
@@ -7,13 +7,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
 
+	"github.com/muhammadharis/goffmpeg/models"
 	"github.com/xfrr/goffmpeg/ffmpeg"
-	"github.com/xfrr/goffmpeg/models"
 	"github.com/xfrr/goffmpeg/utils"
 )
 
@@ -76,6 +77,51 @@ func (t Transcoder) GetCommand() []string {
 	media := t.mediafile
 	rcommand := append([]string{"-y"}, media.ToStrCommand()...)
 	return rcommand
+}
+
+// InitializeTranscoder initializes the fields necessary for a blank transcoder
+func (t *Transcoder) InitializeTranscoder() error {
+	var Metadata models.Metadata
+
+	var err error
+	cfg := t.configuration
+	if len(cfg.FfmpegBin) == 0 || len(cfg.FfprobeBin) == 0 {
+		cfg, err = ffmpeg.Configure()
+		if err != nil {
+			return err
+		}
+	}
+	// Set new Mediafile
+	MediaFile := new(models.Mediafile)
+	MediaFile.SetMetadata(Metadata)
+
+	// Set transcoder configuration
+	t.SetMediaFile(MediaFile)
+	t.SetConfiguration(cfg)
+	return nil
+}
+
+// SetInputPath sets the input path for transcoding
+func (t *Transcoder) SetInputPath(inputPath string) error {
+	if t.mediafile.InputPipeCommand() != nil {
+		return errors.New("cannot set an input path when an input pipe command has been set")
+	}
+	t.mediafile.SetInputPath(inputPath)
+	return nil
+}
+
+// CreateInputPipe creates an input pipe for the transcoding process
+func (t *Transcoder) CreateInputPipe(cmd *exec.Cmd) error {
+	if t.mediafile.InputPath() != "" {
+		return errors.New("cannot set an input pipe when an input path exists")
+	}
+	t.mediafile.SetInputPipeCommand(cmd)
+	return nil
+}
+
+// SetOutputPath sets the output path for transcoding
+func (t *Transcoder) SetOutputPath(outputPath string) {
+	t.mediafile.SetOutputPath(outputPath)
 }
 
 // Initialize Init the transcoding process
@@ -156,6 +202,12 @@ func (t *Transcoder) Run(progress bool) <-chan error {
 		proc.Stdout = out
 	}
 
+	// If an input pipe has been set, we get the command and set it as stdin for the transcoding
+	if t.mediafile.InputPipeCommand() != nil {
+		proc.Stdin, err = t.mediafile.InputPipeCommand().StdoutPipe()
+		proc.Stdout = os.Stdout
+	}
+
 	err = proc.Start()
 
 	t.SetProcess(proc)
@@ -165,6 +217,15 @@ func (t *Transcoder) Run(progress bool) <-chan error {
 			close(done)
 			return
 		}
+
+		// Run the pipe-in command if it's been set
+		if t.mediafile.InputPipeCommand() != nil {
+			err = t.mediafile.InputPipeCommand().Run()
+			if err != nil {
+				err = fmt.Errorf("Failed execution of pipe-in command (%s) with %s", t.mediafile.InputPipeCommand().Args, err)
+			}
+		}
+
 		err = proc.Wait()
 		if err != nil {
 			err = fmt.Errorf("Failed Finish FFMPEG (%s) with %s message %s", command, err, out.String())


### PR DESCRIPTION
Opened an [issue](https://github.com/xfrr/goffmpeg/issues/38) a while back regarding this (#38).

Here's the implementation for a pipe-in protocol, with functions added for extensibility for a pipe-out protocol. The implementation for pipe-out may come in a future PR.

I have also included a couple of stylistic changes to improve the look of `README.md`, and to make unit tests easier to run.