### PR TITLE
Add support for -compression_level, -map_metadata and -metadata.

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,16 @@ SetHttpMethod
 SetHttpKeepAlive
 SetOutputPath
 SetOutputFormat
+SetAudioFilter
+SetAudioVariableBitrate
+SetCompressionLevel
+SetFilter
+SetInputInitialOffset
+SetInputPipeCommand
+SetMapMetadata
+SetMetadata
+SetStreamIds
+SetVideoFilter
 ```
 Example
 ```golang

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ SetInputPipeCommand
 SetMapMetadata
 SetMetadata
 SetStreamIds
+SetTags
 SetVideoFilter
 ```
 Example

--- a/models/media.go
+++ b/models/media.go
@@ -63,6 +63,7 @@ type Mediafile struct {
 	skipAudio             bool
 	compressionLevel      int
 	mapMetadata           string
+	tags                  map[string]string
 }
 
 /*** SETTERS ***/
@@ -281,6 +282,10 @@ func (m *Mediafile) SetCompressionLevel(val int) {
 
 func (m *Mediafile) SetMapMetadata(val string) {
 	m.mapMetadata = val
+}
+
+func (m *Mediafile) SetTags(val map[string]string) {
+	m.tags = val
 }
 
 /*** GETTERS ***/
@@ -502,6 +507,10 @@ func (m *Mediafile) MapMetadata() string {
 	return m.mapMetadata
 }
 
+func (m *Mediafile) Tags() map[string]string {
+	return m.tags
+}
+
 /** OPTS **/
 func (m *Mediafile) ToStrCommand() []string {
 	var strCommand []string
@@ -557,6 +566,7 @@ func (m *Mediafile) ToStrCommand() []string {
 		"HttpKeepAlive",
 		"CompressionLevel",
 		"MapMetadata",
+		"Tags",
 		"OutputPath",
 	}
 	for _, name := range opts {
@@ -941,6 +951,17 @@ func (m *Mediafile) ObtainCompressionLevel() []string {
 func (m *Mediafile) ObtainMapMetadata() []string {
 	if m.mapMetadata != "" {
 		return []string{"-map_metadata", m.mapMetadata}
+	}
+	return nil
+}
+
+func (m *Mediafile) ObtainTags() []string {
+	if m.tags != nil && len(m.tags) != 0 {
+		result := []string{}
+		for key, val := range m.tags {
+			result = append(result, []string{"-metadata", fmt.Sprintf("%s=%s", key, val)}...)
+		}
+		return result
 	}
 	return nil
 }

--- a/models/media.go
+++ b/models/media.go
@@ -61,6 +61,8 @@ type Mediafile struct {
 	audioFilter           string
 	skipVideo             bool
 	skipAudio             bool
+	compressionLevel      int
+	mapMetadata           string
 }
 
 /*** SETTERS ***/
@@ -271,6 +273,14 @@ func (m *Mediafile) SetSkipAudio(val bool) {
 
 func (m *Mediafile) SetMetadata(v Metadata) {
 	m.metadata = v
+}
+
+func (m *Mediafile) SetCompressionLevel(val int) {
+	m.compressionLevel = val
+}
+
+func (m *Mediafile) SetMapMetadata(val string) {
+	m.mapMetadata = val
 }
 
 /*** GETTERS ***/
@@ -484,6 +494,14 @@ func (m *Mediafile) Metadata() Metadata {
 	return m.metadata
 }
 
+func (m *Mediafile) CompressionLevel() int {
+	return m.compressionLevel
+}
+
+func (m *Mediafile) MapMetadata() string {
+	return m.mapMetadata
+}
+
 /** OPTS **/
 func (m *Mediafile) ToStrCommand() []string {
 	var strCommand []string
@@ -537,6 +555,8 @@ func (m *Mediafile) ToStrCommand() []string {
 		"VideoFilter",
 		"HttpMethod",
 		"HttpKeepAlive",
+		"CompressionLevel",
+		"MapMetadata",
 		"OutputPath",
 	}
 	for _, name := range opts {
@@ -907,6 +927,20 @@ func (m *Mediafile) ObtainStreamIds() []string {
 			result = append(result, []string{"-streamid", fmt.Sprintf("%d:%s", i, val)}...)
 		}
 		return result
+	}
+	return nil
+}
+
+func (m *Mediafile) ObtainCompressionLevel() []string {
+	if m.compressionLevel != 0 {
+		return []string{"-compression_level", fmt.Sprintf("%d", m.compressionLevel)}
+	}
+	return nil
+}
+
+func (m *Mediafile) ObtainMapMetadata() []string {
+	if m.mapMetadata != "" {
+		return []string{"-map_metadata", m.mapMetadata}
 	}
 	return nil
 }


### PR DESCRIPTION
Technically `SetTags()` should be `SetMetadata`, but that’s already taken. I couldn't figure out a way to set the metadata using the existing `Tags` struct (`MediaFile().Metadata().Format.Tags`), but happy to remove `SetTags()` is there is a way to do it using the existing structures. 

@xfrr any thoughts?