### PR TITLE
Add SetPixFmt()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/xfrr/goffmpeg
+
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,0 @@
-module github.com/xfrr/goffmpeg
-
-go 1.13

--- a/models/media.go
+++ b/models/media.go
@@ -61,6 +61,7 @@ type Mediafile struct {
 	audioFilter           string
 	skipVideo             bool
 	skipAudio             bool
+	pixFmt                string
 }
 
 /*** SETTERS ***/
@@ -143,6 +144,10 @@ func (m *Mediafile) SetAudioBitRate(v string) {
 
 func (m *Mediafile) SetAudioChannels(v int) {
 	m.audioChannels = v
+}
+
+func (m *Mediafile) SetPixFmt(v string) {
+	m.pixFmt = v
 }
 
 func (m *Mediafile) SetBufferSize(v int) {
@@ -322,6 +327,10 @@ func (m *Mediafile) Vframes() int {
 
 func (m *Mediafile) FrameRate() int {
 	return m.frameRate
+}
+
+func (m *Mediafile) GetPixFmt() string {
+	return m.pixFmt
 }
 
 func (m *Mediafile) AudioRate() int {
@@ -523,6 +532,7 @@ func (m *Mediafile) ToStrCommand() []string {
 		"Threads",
 		"KeyframeInterval",
 		"Preset",
+		"PixFmt",
 		"Tune",
 		"Target",
 		"SeekTime",
@@ -871,6 +881,14 @@ func (m *Mediafile) ObtainHlsSegmentDuration() []string {
 func (m *Mediafile) ObtainHttpMethod() []string {
 	if m.httpMethod != "" {
 		return []string{"-method", m.httpMethod}
+	} else {
+		return nil
+	}
+}
+
+func (m *Mediafile) ObtainPixFmt() []string {
+	if m.pixFmt != "" {
+		return []string{"-pix_fmt", m.pixFmt}
 	} else {
 		return nil
 	}


### PR DESCRIPTION
Encoding one animated format (e.g., GIF) to another (e.g., WEBM via libvpx) requires explicit declaration of the pixel format, lest you be met with an error.

This is a couple-line modification to ./models/media.go which adds `SetPixFmt()` and the related functions to allow setting the `pix_fmt` value sent to FFMPEG.