### PR TITLE
Fix (*Mediafile).ObtainMovFlags redeclared in this block

### DIFF
--- a/models/media.go
+++ b/models/media.go
@@ -1158,10 +1158,3 @@ func (m *Mediafile) ObtainTags() []string {
   }
   return nil
 }
-
-func (m *Mediafile) ObtainMovFlags() []string {
-	if m.movflags != "" {
-		return []string{"-movflags", m.movflags}
-	}
-	return nil
-}


### PR DESCRIPTION
Resolving an redeclaration issue #50 #51. Already declared on line 772.