### PR TITLE
Skip an empty -hls_key_info_file parameter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     docker:
       # specify the version
-      - image: circleci/golang:1.11
+      - image: circleci/golang:1.14
         environment:
           GO111MODULE: "on"
 
@@ -12,5 +12,5 @@ jobs:
       - checkout
 
       # specify any bash command here prefixed with `run: `
-      - run: go mod vendor
-      - run: go test -v ./tests/...
+      - run: go mod download
+      - run: go test -failfast -v -run=. ./...

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     docker:
       # specify the version
-      - image: circleci/golang:1.14
+      - image: circleci/golang:1.14-buster
         environment:
           GO111MODULE: "on"
 
@@ -12,5 +12,6 @@ jobs:
       - checkout
 
       # specify any bash command here prefixed with `run: `
+      - run: sudo apt-get update && sudo apt-get install ffmpeg
       - run: go mod download
       - run: go test -failfast -v -run=. ./...

--- a/models/media.go
+++ b/models/media.go
@@ -1138,7 +1138,11 @@ func (m *Mediafile) ObtainMapMetadata() []string {
 }
     
 func (m *Mediafile) ObtainEncryptionKey() []string {
-	return []string{"-hls_key_info_file", m.encryptionKey}
+	if m.encryptionKey != "" {
+		return []string{"-hls_key_info_file", m.encryptionKey}
+	}
+
+	return nil
 }
 
 func (m *Mediafile) ObtainBframe() []string {

--- a/models/media_test.go
+++ b/models/media_test.go
@@ -1,0 +1,21 @@
+package models
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestMedia(t *testing.T) {
+	t.Run("#ObtainEncryptionKey", func(t *testing.T) {
+		t.Run("Should get nil if encryptionKey is not set", func(t *testing.T) {
+			mediaFile := Mediafile{}
+
+			require.Nil(t, mediaFile.ObtainEncryptionKey())
+		})
+
+		t.Run("Should return file.keyinfo if it's set", func(t *testing.T) {
+			mediaFile := Mediafile{encryptionKey: "file.keyinfo"}
+			require.Equal(t, []string{"-hls_key_info_file", "file.keyinfo"}, mediaFile.ObtainEncryptionKey())
+		})
+	})
+}


### PR DESCRIPTION
Fix problem to include an empty parameter `-hls_key_info_file` to argument list for transcode command