### PR TITLE
This makes transcoder.Output() work again.

### DIFF
--- a/transcoder/transcoder.go
+++ b/transcoder/transcoder.go
@@ -224,7 +224,6 @@ func (t *Transcoder) Run(progress bool) <-chan error {
 	var outb, errb bytes.Buffer
 	if progress {
 		proc.Stdout = &outb
-		proc.Stderr = &errb
 	}
 
 	// If an input pipe has been set, we set it as stdin for the transcoding


### PR DESCRIPTION
Since errb is not really handled later on anyway and errors from ffmpeg are still printed, I think this change only makes sense. 
credit to https://github.com/xfrr/goffmpeg/issues/54#issuecomment-616273992