### PR TITLE
 Update Transcoder.mediafile.Metadata on SetInputPath 

### DIFF
--- a/transcoder/transcoder.go
+++ b/transcoder/transcoder.go
@@ -121,7 +121,7 @@ func (t *Transcoder) SetInputPath(inputPath string) error {
 	var Metadata models.Metadata
 
 	if inputPath == "" {
-		return errors.New("error on transcoder.Initialize: inputPath missing")
+		return errors.New("error on transcoder.SetInputPath: inputPath missing")
 	}
 
 	command := []string{"-i", inputPath, "-print_format", "json", "-show_format", "-show_streams", "-show_error"}


### PR DESCRIPTION
Adding the Metadata for files when using SetInputPath allows for
progress tracking when using a inputPath and a outputPipe. The example
below should be able to track progress percentage but can't before this
commit due to the lack of the duration in the Metadata.
```
err := trans.InitializeEmptyTranscoder()
// handle errors ...
err = trans.SetInputPath(input)
// handle errors ...
r, err := trans.CreateOutputPipe("mp4")
// handle errors ...
```

It should also fix the potential issue of having the MetaData for
another file if SetInputPath is called after initialising the transcoder
with `Transcoder.Initialize(inputPath, outputPath)`.