### PR TITLE
Pass failed command to improve error reporting

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"bytes"
+	"fmt"
 	"os/exec"
 	"runtime"
 	"strconv"
@@ -86,7 +87,7 @@ func TestCmd(command string, args string) (bytes.Buffer, error) {
 
 	err := cmd.Run()
 	if err != nil {
-		return out, err
+		return out, fmt.Errorf("%s: %s", cmd.String(), err)
 	}
 
 	return out, nil


### PR DESCRIPTION
The TestCmd function only returns the exit code without passing information on what has failed. It is very useful to know `which ffmped` or `which ffprobe` are failing to go and simply install them.

With the proposed change, when ffmpeg isn't installed, the error will be `/usr/bin/which ffmpeg: exit status 1` instead of just `exit status 1`